### PR TITLE
Updated Readme.MD: scss-lint is now scss_lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Run these commands to set up the documentation:
 ```bash
 git clone https://github.com/zurb/foundation-sites
 cd foundation-sites
-gem install scss-lint
+gem install scss_lint
 npm install
 ```
 


### PR DESCRIPTION
`gem install scss-lint` produces:
```
WARNING: `scss-lint` has been renamed to `scss_lint` to follow proper RubyGems naming conventions. Update your Gemfile or relevant install scripts to install `scss_lint`.
```
The hyphenated version picks up the older version 0.38, instead of the latest release.
